### PR TITLE
add support for alacritty

### DIFF
--- a/alacritty/LuciusBlack.yml
+++ b/alacritty/LuciusBlack.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusBlack)
+colors:
+  # Default colors
+  primary:
+    background: '#121212'
+    foreground: '#d7d7d7'
+
+  # Cursor colors
+  cursor:
+    text: '#121212'
+    cursor: '#87afd7'
+
+  # Normal colors
+  normal:
+    black:   '#121212'
+    red:     '#ff5f5f'
+    green:   '#afd787'
+    yellow:  '#d7d7af'
+    blue:    '#87d7ff'
+    magenta: '#d7afd7'
+    cyan:    '#87d7af'
+    white:   '#d7d7d7'
+
+  # Bright colors
+  bright:
+    black:   '#121212'
+    red:     '#ff5f5f'
+    green:   '#afd787'
+    yellow:  '#d7d7af'
+    blue:    '#87d7ff'
+    magenta: '#d7afd7'
+    cyan:    '#87d7af'
+    white:   '#d7d7d7'

--- a/alacritty/LuciusBlackHighContrast.yml
+++ b/alacritty/LuciusBlackHighContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusBlackHighContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#121212'
+    foreground: '#eeeeee'
+
+  # Cursor colors
+  cursor:
+    text: '#121212'
+    cursor: '#afd7ff'
+
+  # Normal colors
+  normal:
+    black:   '#121212'
+    red:     '#ff8787'
+    green:   '#d7ffaf'
+    yellow:  '#ffffd7'
+    blue:    '#afffff'
+    magenta: '#ffd7ff'
+    cyan:    '#afffd7'
+    white:   '#eeeeee'
+
+  # Bright colors
+  bright:
+    black:   '#121212'
+    red:     '#ff8787'
+    green:   '#d7ffaf'
+    yellow:  '#ffffd7'
+    blue:    '#afffff'
+    magenta: '#ffd7ff'
+    cyan:    '#afffd7'
+    white:   '#eeeeee'

--- a/alacritty/LuciusBlackLowContrast.yml
+++ b/alacritty/LuciusBlackLowContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusBlackLowContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#121212'
+    foreground: '#bcbcbc'
+
+  # Cursor colors
+  cursor:
+    text: '#121212'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#121212'
+    red:     '#d75f5f'
+    green:   '#87af5f'
+    yellow:  '#afaf87'
+    blue:    '#5fafd7'
+    magenta: '#af87af'
+    cyan:    '#5faf87'
+    white:   '#bcbcbc'
+
+  # Bright colors
+  bright:
+    black:   '#121212'
+    red:     '#d75f5f'
+    green:   '#87af5f'
+    yellow:  '#afaf87'
+    blue:    '#5fafd7'
+    magenta: '#af87af'
+    cyan:    '#5faf87'
+    white:   '#bcbcbc'

--- a/alacritty/LuciusDark.yml
+++ b/alacritty/LuciusDark.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusDark)
+colors:
+  # Default colors
+  primary:
+    background: '#303030'
+    foreground: '#d7d7d7'
+
+  # Cursor colors
+  cursor:
+    text: '#303030'
+    cursor: '#87afd7'
+
+  # Normal colors
+  normal:
+    black:   '#303030'
+    red:     '#ff5f5f'
+    green:   '#afd787'
+    yellow:  '#d7d7af'
+    blue:    '#87d7ff'
+    magenta: '#d7afd7'
+    cyan:    '#87d7af'
+    white:   '#d7d7d7'
+
+  # Bright colors
+  bright:
+    black:   '#303030'
+    red:     '#ff5f5f'
+    green:   '#afd787'
+    yellow:  '#d7d7af'
+    blue:    '#87d7ff'
+    magenta: '#d7afd7'
+    cyan:    '#87d7af'
+    white:   '#d7d7d7'

--- a/alacritty/LuciusDarkHighContrast.yml
+++ b/alacritty/LuciusDarkHighContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusDarkHighContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#303030'
+    foreground: '#eeeeee'
+
+  # Cursor colors
+  cursor:
+    text: '#303030'
+    cursor: '#afd7ff'
+
+  # Normal colors
+  normal:
+    black:   '#303030'
+    red:     '#ff8787'
+    green:   '#d7ffaf'
+    yellow:  '#ffffd7'
+    blue:    '#afffff'
+    magenta: '#ffd7ff'
+    cyan:    '#afffd7'
+    white:   '#eeeeee'
+
+  # Bright colors
+  bright:
+    black:   '#303030'
+    red:     '#ff8787'
+    green:   '#d7ffaf'
+    yellow:  '#ffffd7'
+    blue:    '#afffff'
+    magenta: '#ffd7ff'
+    cyan:    '#afffd7'
+    white:   '#eeeeee'

--- a/alacritty/LuciusDarkLowContrast.yml
+++ b/alacritty/LuciusDarkLowContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusDarkLowContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#303030'
+    foreground: '#bcbcbc'
+
+  # Cursor colors
+  cursor:
+    text: '#303030'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#303030'
+    red:     '#d75f5f'
+    green:   '#87af5f'
+    yellow:  '#afaf87'
+    blue:    '#5fafd7'
+    magenta: '#af87af'
+    cyan:    '#5faf87'
+    white:   '#bcbcbc'
+
+  # Bright colors
+  bright:
+    black:   '#303030'
+    red:     '#d75f5f'
+    green:   '#87af5f'
+    yellow:  '#afaf87'
+    blue:    '#5fafd7'
+    magenta: '#af87af'
+    cyan:    '#5faf87'
+    white:   '#bcbcbc'

--- a/alacritty/LuciusLight.yml
+++ b/alacritty/LuciusLight.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusLight)
+colors:
+  # Default colors
+  primary:
+    background: '#eeeeee'
+    foreground: '#444444'
+
+  # Cursor colors
+  cursor:
+    text: '#eeeeee'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#444444'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#eeeeee'
+
+  # Bright colors
+  bright:
+    black:   '#444444'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#eeeeee'

--- a/alacritty/LuciusLightHighContrast.yml
+++ b/alacritty/LuciusLightHighContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusLightHighContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#eeeeee'
+    foreground: '#000000'
+
+  # Cursor colors
+  cursor:
+    text: '#eeeeee'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#000000'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#eeeeee'
+
+  # Bright colors
+  bright:
+    black:   '#000000'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#eeeeee'

--- a/alacritty/LuciusLightLowContrast.yml
+++ b/alacritty/LuciusLightLowContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusLightLowContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#eeeeee'
+    foreground: '#626262'
+
+  # Cursor colors
+  cursor:
+    text: '#eeeeee'
+    cursor: '#87afd7'
+
+  # Normal colors
+  normal:
+    black:   '#626262'
+    red:     '#d70000'
+    green:   '#00af00'
+    yellow:  '#d78700'
+    blue:    '#0087d7'
+    magenta: '#af00af'
+    cyan:    '#00afaf'
+    white:   '#eeeeee'
+
+  # Bright colors
+  bright:
+    black:   '#626262'
+    red:     '#d70000'
+    green:   '#00af00'
+    yellow:  '#d78700'
+    blue:    '#0087d7'
+    magenta: '#af00af'
+    cyan:    '#00afaf'
+    white:   '#eeeeee'

--- a/alacritty/LuciusWhite.yml
+++ b/alacritty/LuciusWhite.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusWhite)
+colors:
+  # Default colors
+  primary:
+    background: '#ffffff'
+    foreground: '#444444'
+
+  # Cursor colors
+  cursor:
+    text: '#ffffff'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#444444'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#ffffff'
+
+  # Bright colors
+  bright:
+    black:   '#444444'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#ffffff'

--- a/alacritty/LuciusWhiteHighContrast.yml
+++ b/alacritty/LuciusWhiteHighContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusWhiteHighContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#ffffff'
+    foreground: '#000000'
+
+  # Cursor colors
+  cursor:
+    text: '#ffffff'
+    cursor: '#5f87af'
+
+  # Normal colors
+  normal:
+    black:   '#000000'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#ffffff'
+
+  # Bright colors
+  bright:
+    black:   '#000000'
+    red:     '#af0000'
+    green:   '#008700'
+    yellow:  '#af5f00'
+    blue:    '#005faf'
+    magenta: '#870087'
+    cyan:    '#008787'
+    white:   '#ffffff'

--- a/alacritty/LuciusWhiteLowContrast.yml
+++ b/alacritty/LuciusWhiteLowContrast.yml
@@ -1,0 +1,33 @@
+# Colors (LuciusWhiteLowContrast)
+colors:
+  # Default colors
+  primary:
+    background: '#ffffff'
+    foreground: '#626262'
+
+  # Cursor colors
+  cursor:
+    text: '#ffffff'
+    cursor: '#87afd7'
+
+  # Normal colors
+  normal:
+    black:   '#626262'
+    red:     '#d70000'
+    green:   '#00af00'
+    yellow:  '#d78700'
+    blue:    '#0087d7'
+    magenta: '#af00af'
+    cyan:    '#00afaf'
+    white:   '#ffffff'
+
+  # Bright colors
+  bright:
+    black:   '#626262'
+    red:     '#d70000'
+    green:   '#00af00'
+    yellow:  '#d78700'
+    blue:    '#0087d7'
+    magenta: '#af00af'
+    cyan:    '#00afaf'
+    white:   '#ffffff'

--- a/lucius.py
+++ b/lucius.py
@@ -179,12 +179,12 @@ def write_iterm2(name):
         entries.append(template_item % d)
     other_colors = {}
     other_colors["Background Color"] = get_bg("Normal")
-    other_colors["Bold Color"] = get_fg("Normal")
-    other_colors["Cursor Color"] = get_bg("Cursor")
-    other_colors["Cursor Text Color"] = get_bg("Normal")
     other_colors["Foreground Color"] = get_fg("Normal")
     other_colors["Selected Text Color"] = get_fg("Normal")
+    other_colors["Bold Color"] = get_fg("Normal")
     other_colors["Selection Color"] = get_bg("Visual")
+    other_colors["Cursor Text Color"] = get_bg("Normal")
+    other_colors["Cursor Color"] = get_bg("Cursor")
     for c in other_colors:
         d = dict(
                 name=c,

--- a/lucius.py
+++ b/lucius.py
@@ -233,6 +233,18 @@ def write_xfce4(name):
     with open(path, "w") as fd:
         fd.write(template)
 
+def write_alacritty(name):
+    template_path = os.path.join(ROOT_DIR, "templates", "alacritty.txt")
+    colors = get_ansi_colors(mode="hex")
+    colors["name"] = name
+    path = os.path.join(ROOT_DIR, "alacritty", name + ".yml")
+    template = ""
+    with open(template_path, "r") as fd:
+        template = fd.read()
+    template = template % colors
+    with open(path, "w") as fd:
+        fd.write(template)
+
 def main():
     for scheme in SCHEMES:
         vim.command(scheme)
@@ -241,6 +253,7 @@ def main():
         write_xresources(scheme)
         write_mintty(scheme)
         write_xfce4(scheme)
+        write_alacritty(scheme)
 
 
 if __name__ == "__main__":

--- a/lucius.py
+++ b/lucius.py
@@ -8,13 +8,14 @@ the vim color scheme, "Lucius". This script must be run from within Vim!
 """
 
 
+import inspect
 import os
 import sys
 
 import vim
 
 
-ROOT_DIR = os.path.join(os.environ.get("HOME"), "lucius")
+ROOT_DIR = os.path.dirname(inspect.getfile(inspect.currentframe()))
 SCHEMES = [
         "LuciusWhite",
         "LuciusWhiteHighContrast",

--- a/lucius.py
+++ b/lucius.py
@@ -167,7 +167,7 @@ def write_iterm2(name):
     with open(template_item_path, "r") as fd:
         template_item = fd.read()
     entries = []
-    for i in xrange(16):
+    for i in range(16):
         item_name = "Ansi %d Color" % i
         d = dict(
                 name=item_name,

--- a/templates/alacritty.txt
+++ b/templates/alacritty.txt
@@ -1,0 +1,33 @@
+# Colors (%(name)s)
+colors:
+  # Default colors
+  primary:
+    background: '%(bg)s'
+    foreground: '%(fg)s'
+
+  # Cursor colors
+  cursor:
+    text: '%(cursor_text)s'
+    cursor: '%(cursor)s'
+
+  # Normal colors
+  normal:
+    black:   '%(black)s'
+    red:     '%(red)s'
+    green:   '%(green)s'
+    yellow:  '%(yellow)s'
+    blue:    '%(blue)s'
+    magenta: '%(magenta)s'
+    cyan:    '%(cyan)s'
+    white:   '%(white)s'
+
+  # Bright colors
+  bright:
+    black:   '%(black_bold)s'
+    red:     '%(red_bold)s'
+    green:   '%(green_bold)s'
+    yellow:  '%(yellow_bold)s'
+    blue:    '%(blue_bold)s'
+    magenta: '%(magenta_bold)s'
+    cyan:    '%(cyan_bold)s'
+    white:   '%(white_bold)s'


### PR DESCRIPTION
This PR adds a new template to create config files for [Alacritty](https://github.com/alacritty/alacritty). I had to tweak `lucius.py` to get it to run with Python 3, since my vim loaded that first and wouldn't let me run it on Python 2. I also tweaked how it calculated `ROOT_DIR` to make sure that it worked with the location of the repo where i had it.

I also added an extra commit to fix the ordering for the iTerm 2 generator - it looks like the version of `lucius.py` on master causes the colors to get shuffled some when you run the script. With that commit, now running `lucius.py` will generate identical files to what's already there.

If you don't want the extra changes in there, let me know and i can toss out everything but the last commit.