### PR TITLE
Use LineNr instead of Normal to get ansi7 (silver) and ansi8 (grey)

### DIFF
--- a/iterm2/LuciusBlack.itermcolors
+++ b/iterm2/LuciusBlack.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusBlackHighContrast.itermcolors
+++ b/iterm2/LuciusBlackHighContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusBlackLowContrast.itermcolors
+++ b/iterm2/LuciusBlackLowContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.070588</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusDark.itermcolors
+++ b/iterm2/LuciusDark.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.843137</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusDarkHighContrast.itermcolors
+++ b/iterm2/LuciusDarkHighContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.933333</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusDarkLowContrast.itermcolors
+++ b/iterm2/LuciusDarkLowContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
         <key>Green Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
         <key>Red Component</key>
-        <real>0.737255</real>
+        <real>0.384314</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Green Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
         <key>Red Component</key>
-        <real>0.188235</real>
+        <real>0.266667</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusLight.itermcolors
+++ b/iterm2/LuciusLight.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusLightHighContrast.itermcolors
+++ b/iterm2/LuciusLightHighContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusLightLowContrast.itermcolors
+++ b/iterm2/LuciusLightLowContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>0.933333</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusWhite.itermcolors
+++ b/iterm2/LuciusWhite.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.266667</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusWhiteHighContrast.itermcolors
+++ b/iterm2/LuciusWhiteHighContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.000000</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/iterm2/LuciusWhiteLowContrast.itermcolors
+++ b/iterm2/LuciusWhiteLowContrast.itermcolors
@@ -68,20 +68,20 @@
     <key>Ansi 7 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Green Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
         <key>Red Component</key>
-        <real>1.000000</real>
+        <real>0.854902</real>
     </dict>
     <key>Ansi 8 Color</key>
     <dict>
         <key>Blue Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
         <key>Green Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
         <key>Red Component</key>
-        <real>0.384314</real>
+        <real>0.619608</real>
     </dict>
     <key>Ansi 9 Color</key>
     <dict>

--- a/lucius.py
+++ b/lucius.py
@@ -5,6 +5,10 @@ lucius.py
 
 This script is used to generate color files for various applications that match
 the vim color scheme, "Lucius". This script must be run from within Vim!
+$ vim
+:colorscheme lucius
+:py3file lucius.py
+
 """
 
 
@@ -86,18 +90,18 @@ def get_ansi_colors(mode=None):
     if is_light_background():
         d["ansi0"] = get_fg("Normal")
         d["black"] = get_fg("Normal")
-        d["ansi8"] = get_fg("Normal")
+        d["ansi8"] = get_fg("LineNr")
         d["black_bold"] = get_fg("Normal")
-        d["ansi7"] = get_bg("Normal")
+        d["ansi7"] = get_bg("LineNr")
         d["white"] = get_bg("Normal")
         d["ansi15"] = get_bg("Normal")
         d["white_bold"] = get_bg("Normal")
     else:
         d["ansi0"] = get_bg("Normal")
         d["black"] = get_bg("Normal")
-        d["ansi8"] = get_bg("Normal")
+        d["ansi8"] = get_bg("LineNr")
         d["black_bold"] = get_bg("Normal")
-        d["ansi7"] = get_fg("Normal")
+        d["ansi7"] = get_fg("LineNr")
         d["white"] = get_fg("Normal")
         d["ansi15"] = get_fg("Normal")
         d["white_bold"] = get_fg("Normal")

--- a/xfce4-terminal/LuciusBlack.theme
+++ b/xfce4-terminal/LuciusBlack.theme
@@ -3,4 +3,4 @@ Name=LuciusBlack
 ColorForeground=#d7d7d7
 ColorBackground=#121212
 ColorCursor=#87afd7
-ColorPalette=#121212;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;#121212;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;
+ColorPalette=#121212;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#626262;#444444;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;

--- a/xfce4-terminal/LuciusBlackHighContrast.theme
+++ b/xfce4-terminal/LuciusBlackHighContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusBlackHighContrast
 ColorForeground=#eeeeee
 ColorBackground=#121212
 ColorCursor=#afd7ff
-ColorPalette=#121212;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;#121212;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;
+ColorPalette=#121212;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#626262;#444444;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;

--- a/xfce4-terminal/LuciusBlackLowContrast.theme
+++ b/xfce4-terminal/LuciusBlackLowContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusBlackLowContrast
 ColorForeground=#bcbcbc
 ColorBackground=#121212
 ColorCursor=#5f87af
-ColorPalette=#121212;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;#121212;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;
+ColorPalette=#121212;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#626262;#444444;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;

--- a/xfce4-terminal/LuciusDark.theme
+++ b/xfce4-terminal/LuciusDark.theme
@@ -3,4 +3,4 @@ Name=LuciusDark
 ColorForeground=#d7d7d7
 ColorBackground=#303030
 ColorCursor=#87afd7
-ColorPalette=#303030;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;#303030;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;
+ColorPalette=#303030;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#626262;#444444;#ff5f5f;#afd787;#d7d7af;#87d7ff;#d7afd7;#87d7af;#d7d7d7;

--- a/xfce4-terminal/LuciusDarkHighContrast.theme
+++ b/xfce4-terminal/LuciusDarkHighContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusDarkHighContrast
 ColorForeground=#eeeeee
 ColorBackground=#303030
 ColorCursor=#afd7ff
-ColorPalette=#303030;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;#303030;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;
+ColorPalette=#303030;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#626262;#444444;#ff8787;#d7ffaf;#ffffd7;#afffff;#ffd7ff;#afffd7;#eeeeee;

--- a/xfce4-terminal/LuciusDarkLowContrast.theme
+++ b/xfce4-terminal/LuciusDarkLowContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusDarkLowContrast
 ColorForeground=#bcbcbc
 ColorBackground=#303030
 ColorCursor=#5f87af
-ColorPalette=#303030;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;#303030;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;
+ColorPalette=#303030;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#626262;#444444;#d75f5f;#87af5f;#afaf87;#5fafd7;#af87af;#5faf87;#bcbcbc;

--- a/xfce4-terminal/LuciusLight.theme
+++ b/xfce4-terminal/LuciusLight.theme
@@ -3,4 +3,4 @@ Name=LuciusLight
 ColorForeground=#444444
 ColorBackground=#eeeeee
 ColorCursor=#5f87af
-ColorPalette=#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;
+ColorPalette=#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#dadada;#9e9e9e;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;

--- a/xfce4-terminal/LuciusLightHighContrast.theme
+++ b/xfce4-terminal/LuciusLightHighContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusLightHighContrast
 ColorForeground=#000000
 ColorBackground=#eeeeee
 ColorCursor=#5f87af
-ColorPalette=#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;
+ColorPalette=#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#dadada;#9e9e9e;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#eeeeee;

--- a/xfce4-terminal/LuciusLightLowContrast.theme
+++ b/xfce4-terminal/LuciusLightLowContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusLightLowContrast
 ColorForeground=#626262
 ColorBackground=#eeeeee
 ColorCursor=#87afd7
-ColorPalette=#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#eeeeee;#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#eeeeee;
+ColorPalette=#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#dadada;#9e9e9e;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#eeeeee;

--- a/xfce4-terminal/LuciusWhite.theme
+++ b/xfce4-terminal/LuciusWhite.theme
@@ -3,4 +3,4 @@ Name=LuciusWhite
 ColorForeground=#444444
 ColorBackground=#ffffff
 ColorCursor=#5f87af
-ColorPalette=#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;
+ColorPalette=#444444;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#dadada;#9e9e9e;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;

--- a/xfce4-terminal/LuciusWhiteHighContrast.theme
+++ b/xfce4-terminal/LuciusWhiteHighContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusWhiteHighContrast
 ColorForeground=#000000
 ColorBackground=#ffffff
 ColorCursor=#5f87af
-ColorPalette=#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;
+ColorPalette=#000000;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#dadada;#9e9e9e;#af0000;#008700;#af5f00;#005faf;#870087;#008787;#ffffff;

--- a/xfce4-terminal/LuciusWhiteLowContrast.theme
+++ b/xfce4-terminal/LuciusWhiteLowContrast.theme
@@ -3,4 +3,4 @@ Name=LuciusWhiteLowContrast
 ColorForeground=#626262
 ColorBackground=#ffffff
 ColorCursor=#87afd7
-ColorPalette=#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#ffffff;#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#ffffff;
+ColorPalette=#626262;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#dadada;#9e9e9e;#d70000;#00af00;#d78700;#0087d7;#af00af;#00afaf;#ffffff;

--- a/xresources/LuciusBlack
+++ b/xresources/LuciusBlack
@@ -2,7 +2,7 @@
 *foreground:  #d7d7d7
 *cursorColor: #87afd7
 *color0:      #121212
-*color8:      #121212
+*color8:      #444444
 *color1:      #ff5f5f
 *color9:      #ff5f5f
 *color2:      #afd787
@@ -15,6 +15,6 @@
 *color13:     #d7afd7
 *color6:      #87d7af
 *color14:     #87d7af
-*color7:      #d7d7d7
+*color7:      #626262
 *color15:     #d7d7d7
 

--- a/xresources/LuciusBlackHighContrast
+++ b/xresources/LuciusBlackHighContrast
@@ -2,7 +2,7 @@
 *foreground:  #eeeeee
 *cursorColor: #afd7ff
 *color0:      #121212
-*color8:      #121212
+*color8:      #444444
 *color1:      #ff8787
 *color9:      #ff8787
 *color2:      #d7ffaf
@@ -15,6 +15,6 @@
 *color13:     #ffd7ff
 *color6:      #afffd7
 *color14:     #afffd7
-*color7:      #eeeeee
+*color7:      #626262
 *color15:     #eeeeee
 

--- a/xresources/LuciusBlackLowContrast
+++ b/xresources/LuciusBlackLowContrast
@@ -2,7 +2,7 @@
 *foreground:  #bcbcbc
 *cursorColor: #5f87af
 *color0:      #121212
-*color8:      #121212
+*color8:      #444444
 *color1:      #d75f5f
 *color9:      #d75f5f
 *color2:      #87af5f
@@ -15,6 +15,6 @@
 *color13:     #af87af
 *color6:      #5faf87
 *color14:     #5faf87
-*color7:      #bcbcbc
+*color7:      #626262
 *color15:     #bcbcbc
 

--- a/xresources/LuciusDark
+++ b/xresources/LuciusDark
@@ -2,7 +2,7 @@
 *foreground:  #d7d7d7
 *cursorColor: #87afd7
 *color0:      #303030
-*color8:      #303030
+*color8:      #444444
 *color1:      #ff5f5f
 *color9:      #ff5f5f
 *color2:      #afd787
@@ -15,6 +15,6 @@
 *color13:     #d7afd7
 *color6:      #87d7af
 *color14:     #87d7af
-*color7:      #d7d7d7
+*color7:      #626262
 *color15:     #d7d7d7
 

--- a/xresources/LuciusDarkHighContrast
+++ b/xresources/LuciusDarkHighContrast
@@ -2,7 +2,7 @@
 *foreground:  #eeeeee
 *cursorColor: #afd7ff
 *color0:      #303030
-*color8:      #303030
+*color8:      #444444
 *color1:      #ff8787
 *color9:      #ff8787
 *color2:      #d7ffaf
@@ -15,6 +15,6 @@
 *color13:     #ffd7ff
 *color6:      #afffd7
 *color14:     #afffd7
-*color7:      #eeeeee
+*color7:      #626262
 *color15:     #eeeeee
 

--- a/xresources/LuciusDarkLowContrast
+++ b/xresources/LuciusDarkLowContrast
@@ -2,7 +2,7 @@
 *foreground:  #bcbcbc
 *cursorColor: #5f87af
 *color0:      #303030
-*color8:      #303030
+*color8:      #444444
 *color1:      #d75f5f
 *color9:      #d75f5f
 *color2:      #87af5f
@@ -15,6 +15,6 @@
 *color13:     #af87af
 *color6:      #5faf87
 *color14:     #5faf87
-*color7:      #bcbcbc
+*color7:      #626262
 *color15:     #bcbcbc
 

--- a/xresources/LuciusLight
+++ b/xresources/LuciusLight
@@ -2,7 +2,7 @@
 *foreground:  #444444
 *cursorColor: #5f87af
 *color0:      #444444
-*color8:      #444444
+*color8:      #9e9e9e
 *color1:      #af0000
 *color9:      #af0000
 *color2:      #008700
@@ -15,6 +15,6 @@
 *color13:     #870087
 *color6:      #008787
 *color14:     #008787
-*color7:      #eeeeee
+*color7:      #dadada
 *color15:     #eeeeee
 

--- a/xresources/LuciusLightHighContrast
+++ b/xresources/LuciusLightHighContrast
@@ -2,7 +2,7 @@
 *foreground:  #000000
 *cursorColor: #5f87af
 *color0:      #000000
-*color8:      #000000
+*color8:      #9e9e9e
 *color1:      #af0000
 *color9:      #af0000
 *color2:      #008700
@@ -15,6 +15,6 @@
 *color13:     #870087
 *color6:      #008787
 *color14:     #008787
-*color7:      #eeeeee
+*color7:      #dadada
 *color15:     #eeeeee
 

--- a/xresources/LuciusLightLowContrast
+++ b/xresources/LuciusLightLowContrast
@@ -2,7 +2,7 @@
 *foreground:  #626262
 *cursorColor: #87afd7
 *color0:      #626262
-*color8:      #626262
+*color8:      #9e9e9e
 *color1:      #d70000
 *color9:      #d70000
 *color2:      #00af00
@@ -15,6 +15,6 @@
 *color13:     #af00af
 *color6:      #00afaf
 *color14:     #00afaf
-*color7:      #eeeeee
+*color7:      #dadada
 *color15:     #eeeeee
 

--- a/xresources/LuciusWhite
+++ b/xresources/LuciusWhite
@@ -2,7 +2,7 @@
 *foreground:  #444444
 *cursorColor: #5f87af
 *color0:      #444444
-*color8:      #444444
+*color8:      #9e9e9e
 *color1:      #af0000
 *color9:      #af0000
 *color2:      #008700
@@ -15,6 +15,6 @@
 *color13:     #870087
 *color6:      #008787
 *color14:     #008787
-*color7:      #ffffff
+*color7:      #dadada
 *color15:     #ffffff
 

--- a/xresources/LuciusWhiteHighContrast
+++ b/xresources/LuciusWhiteHighContrast
@@ -2,7 +2,7 @@
 *foreground:  #000000
 *cursorColor: #5f87af
 *color0:      #000000
-*color8:      #000000
+*color8:      #9e9e9e
 *color1:      #af0000
 *color9:      #af0000
 *color2:      #008700
@@ -15,6 +15,6 @@
 *color13:     #870087
 *color6:      #008787
 *color14:     #008787
-*color7:      #ffffff
+*color7:      #dadada
 *color15:     #ffffff
 

--- a/xresources/LuciusWhiteLowContrast
+++ b/xresources/LuciusWhiteLowContrast
@@ -2,7 +2,7 @@
 *foreground:  #626262
 *cursorColor: #87afd7
 *color0:      #626262
-*color8:      #626262
+*color8:      #9e9e9e
 *color1:      #d70000
 *color9:      #d70000
 *color2:      #00af00
@@ -15,6 +15,6 @@
 *color13:     #af00af
 *color6:      #00afaf
 *color14:     #00afaf
-*color7:      #ffffff
+*color7:      #dadada
 *color15:     #ffffff
 


### PR DESCRIPTION
In iterm2, I noticed that vim visual highlighting wasn't "working". The ansi7 and ansi8 colors should be silver and grey, not white and black.

The 'LineNr' highlight defines both of those colors, so I modified lucius.py to use it instead of 'Normal'.

This should fix #2 but I didn't mess with "black_bold" or "white_bold".