### PR TITLE
Add selection colors to Alacritty theme

### DIFF
--- a/alacritty/LuciusBlack.yml
+++ b/alacritty/LuciusBlack.yml
@@ -10,6 +10,11 @@ colors:
     text: '#121212'
     cursor: '#87afd7'
 
+  # Selection colors
+  selection:
+    text: '#d7d7d7'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#121212'

--- a/alacritty/LuciusBlackHighContrast.yml
+++ b/alacritty/LuciusBlackHighContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#121212'
     cursor: '#afd7ff'
 
+  # Selection colors
+  selection:
+    text: '#eeeeee'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#121212'

--- a/alacritty/LuciusBlackLowContrast.yml
+++ b/alacritty/LuciusBlackLowContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#121212'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#bcbcbc'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#121212'

--- a/alacritty/LuciusDark.yml
+++ b/alacritty/LuciusDark.yml
@@ -10,6 +10,11 @@ colors:
     text: '#303030'
     cursor: '#87afd7'
 
+  # Selection colors
+  selection:
+    text: '#d7d7d7'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#303030'

--- a/alacritty/LuciusDarkHighContrast.yml
+++ b/alacritty/LuciusDarkHighContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#303030'
     cursor: '#afd7ff'
 
+  # Selection colors
+  selection:
+    text: '#eeeeee'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#303030'

--- a/alacritty/LuciusDarkLowContrast.yml
+++ b/alacritty/LuciusDarkLowContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#303030'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#bcbcbc'
+    background: '#005f87'
+
   # Normal colors
   normal:
     black:   '#303030'

--- a/alacritty/LuciusLight.yml
+++ b/alacritty/LuciusLight.yml
@@ -10,6 +10,11 @@ colors:
     text: '#eeeeee'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#444444'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#444444'

--- a/alacritty/LuciusLightHighContrast.yml
+++ b/alacritty/LuciusLightHighContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#eeeeee'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#000000'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#000000'

--- a/alacritty/LuciusLightLowContrast.yml
+++ b/alacritty/LuciusLightLowContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#eeeeee'
     cursor: '#87afd7'
 
+  # Selection colors
+  selection:
+    text: '#626262'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#626262'

--- a/alacritty/LuciusWhite.yml
+++ b/alacritty/LuciusWhite.yml
@@ -10,6 +10,11 @@ colors:
     text: '#ffffff'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#444444'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#444444'

--- a/alacritty/LuciusWhiteHighContrast.yml
+++ b/alacritty/LuciusWhiteHighContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#ffffff'
     cursor: '#5f87af'
 
+  # Selection colors
+  selection:
+    text: '#000000'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#000000'

--- a/alacritty/LuciusWhiteLowContrast.yml
+++ b/alacritty/LuciusWhiteLowContrast.yml
@@ -10,6 +10,11 @@ colors:
     text: '#ffffff'
     cursor: '#87afd7'
 
+  # Selection colors
+  selection:
+    text: '#626262'
+    background: '#afd7ff'
+
   # Normal colors
   normal:
     black:   '#626262'

--- a/lucius.py
+++ b/lucius.py
@@ -136,6 +136,8 @@ def get_ansi_colors(mode=None):
     d["bg_bold"] = get_bg("Normal")
     d["cursor_text"] = get_bg("Normal")
     d["cursor"] = get_bg("Cursor")
+    d["selection_text"] = get_fg("Normal")
+    d["selection"] = get_bg("Visual")
 
     if mode is not None:
         if mode == "rgb":

--- a/templates/alacritty.txt
+++ b/templates/alacritty.txt
@@ -10,6 +10,11 @@ colors:
     text: '%(cursor_text)s'
     cursor: '%(cursor)s'
 
+  # Selection colors
+  selection:
+    text: '%(selection_text)s'
+    background: '%(selection)s'
+
   # Normal colors
   normal:
     black:   '%(black)s'


### PR DESCRIPTION
The default selection color used by Alacritty is pretty unreadable. This change explicitly sets the selection color based on Visual (like for iTerm2).